### PR TITLE
DI-1554 eunomia workflow v.1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DNAnexus workflow to support the Pan-Cancer service
 |---	|---	|
 |eggd_staraligner       |[1.0.2](https://github.com/eastgenomics/eggd_staraligner/releases/tag/v1.0.2)|
 |eggd_starfusion           |[1.0.0](https://github.com/eastgenomics/eggd_starfusion/releases/tag/v1.0.0)|
-|eggd_fusioninspector             |[1.0.0](https://github.com/eastgenomics/eggd_fusioninspector/releases/tag/v1.0.0)|
+|eggd_fusioninspector             |[1.1.0](https://github.com/eastgenomics/eggd_fusioninspector/releases/tag/v1.1.0)|
 |eggd_RNASeQC |[1.1.1](https://github.com/eastgenomics/eggd_RNASeQC/releases/tag/v1.1.1)|
 |eggd_picard_QC           |[1.1.0](https://github.com/eastgenomics/eggd_picardqc/releases/tag/v1.1.0)|
 |eggd_fastqc |[1.2.0](https://github.com/eastgenomics/eggd_fastqc/releases/tag/v1.2.0)|

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "eunomia_workflow_v1.0.0",
-  "title": "eunomia_workflow_v1.0.0",
+  "name": "eunomia_workflow_v1.1.0",
+  "title": "eunomia_workflow_v1.1.0",
   "stages": [
     {
       "id": "stage-staraligner",
@@ -17,121 +17,20 @@
             "stage": "stage-staraligner",
             "outputField": "chimeric_junctions"
           }
-        },
-        "sf_docker": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GGygFkQ4Y6Yjp0jpBjgV9VZx"
-          }
-        },
-        "genome_lib": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GJfX12j41p4GY5K3PY65VFjj"
-          }
         }
       }
     },
     {
-      "id": "stage-fusioninspector_scientist",
-      "executable": "app-eggd_fusioninspector/1.0.0",
-      "folder": "eggd_fusioninspector_scientist_v1.0.0",
+      "id": "stage-fusioninspector",
+      "executable": "app-eggd_fusioninspector/1.1.0",
+      "folder": "eggd_fusioninspector_v1.1.0",
       "input": {
-        "fi_docker": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GGzFp2Q43Gg5Y56p8yfGjPYb"
-          }
-        },
-        "known_fusions": [
-          {
-            "$dnanexus_link": {
-              "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-              "id": "file-GpQXz1j4JJKX9PPVpKpBzV7Q"
-            }
-          }
-        ],
-        "genome_lib": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GJfX12j41p4GY5K3PY65VFjj"
-          }
-        },
         "sr_predictions": {
           "$dnanexus_link": {
             "stage": "stage-starfusion",
             "outputField": "starfusion_predictions"
-          }
-        },
-        "include_trinity": true
-      }
-    },
-    {
-      "id": "stage-fusioninspector_rnaopa",
-      "executable": "app-eggd_fusioninspector/1.0.0",
-      "folder": "eggd_fusioninspector_rnaopa_v1.0.0",
-      "input": {
-        "fi_docker": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GGzFp2Q43Gg5Y56p8yfGjPYb"
-          }
-        },
-        "genome_lib": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GJfX12j41p4GY5K3PY65VFjj"
-          }
-        },
-        "known_fusions": [
-          {
-            "$dnanexus_link": {
-              "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-              "id": "file-GpGQq8j4JJKgbjK5z5gGxx6K"
-            }
-          }
-        ],
-        "sr_predictions": {
-          "$dnanexus_link": {
-            "stage": "stage-starfusion",
-            "outputField": "starfusion_predictions"
-          }
-        },
-        "include_trinity": true
-      }
-    },
-    {
-      "id": "stage-fusioninspector_testdir_cosmic",
-      "executable": "app-eggd_fusioninspector/1.0.0",
-      "folder": "eggd_fusioninspector_testdir_cosmic_v1.0.0",
-      "input": {
-        "fi_docker": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GGzFp2Q43Gg5Y56p8yfGjPYb"
-          }
-        },
-        "genome_lib": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GJfX12j41p4GY5K3PY65VFjj"
-          }
-        },
-        "known_fusions": [
-        {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GpGVQZj4JJKy6vGyZz2GQ2p2"
           }
         }
-      ],
-        "sr_predictions": {
-          "$dnanexus_link": {
-            "stage": "stage-starfusion",
-            "outputField": "starfusion_predictions"
-          }
-        },
-        "include_trinity": true
       }
     },
     {
@@ -139,28 +38,10 @@
       "executable": "app-eggd_RNASeQC/1.1.1",
       "folder": "eggd_rnaseqc_v1.1.1",
       "input": {
-        "docker": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-Gp2YvGj43p6bP660QjZ6zV60"
-          }
-        },
-        "CTAT_bundle": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GJfX12j41p4GY5K3PY65VFjj"
-          }
-        },
         "bam": {
           "$dnanexus_link": {
             "stage": "stage-staraligner",
             "outputField": "output_bam"
-          }
-        },
-        "bed": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-Gp8Xxv842QQqKY9Z5938xQP0"
           }
         }
       }
@@ -170,21 +51,12 @@
       "executable": "app-eggd_picard_QC/1.1.0",
       "folder": "eggd_picard_v1.1.0",
       "input": {
-        "fasta_index": {
-          "$dnanexus_link": {
-            "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-            "id": "file-GJfX12j41p4GY5K3PY65VFjj"
-          }
-        },
         "sorted_bam": {
           "$dnanexus_link": {
             "stage": "stage-staraligner",
             "outputField": "output_bam"
           }
-        },
-        "run_CollectMultipleMetrics": false,
-        "run_CollectHsMetrics": false,
-        "run_CollectRnaSeqMetrics": true
+        }
       },
       "systemRequirements": {
         "*": {


### PR DESCRIPTION
- Removed static inputs files, these will be in eggd_conductor_eunomia_PCAN_config (example: file-J0XFGx844bkPk72yJG6jVJ97)
- Updated fusioninspector app version from v1.0.0 to v1.1.0.
- Keep only one app of fusioninspector rather than three. 

Example of workflow set off by conductor: https://platform.dnanexus.com/panx/projects/GxX2YVj44bk8PBQBGb4Qk6f1/monitor/analysis/J0XFK7Q44bkGK21pzgJgvxkz

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_eunomia_workflow/8)
<!-- Reviewable:end -->
